### PR TITLE
ci(configure-code-climate-tool): configure code-climate analysis tool

### DIFF
--- a/.github/workflows/test-runner.yml
+++ b/.github/workflows/test-runner.yml
@@ -1,7 +1,13 @@
 name: Test Runner
 
 on:
-  pull_request
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+
+permissions:
+  contents: read
 
 jobs:
   test-runner:
@@ -20,6 +26,16 @@ jobs:
         run: pip install -r requirements.txt
       - name: Install test requirements
         run: pip install -r test-requirements.txt
-      - name: Run tests w/ coverage report
+      - name: Run tests
         # Run tox using the version of Python in `PATH`
-        run: pytest --cov apimatic_requests_client_adapter/
+        run: coverage run -m pytest
+      - name: Generate coverage report
+        run: coverage xml
+      - name: Upload coverage report
+        if: ${{ matrix.os == 'ubuntu-latest' && matrix.python == '3.10' }}
+        uses: paambaati/codeclimate-action@v3.0.0
+        env:
+          CC_TEST_REPORTER_ID: ${{ secrets.CODE_CLIMATE_TEST_REPORTER_ID }}
+        with:
+          coverageLocations: |
+            ${{github.workspace}}/coverage.xml:coverage.py

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # apimatic-requests-client-adapter
-[![PyPI][pypi-version]](https://pypi.org/project/apimatic-requests-client-adapter/)
+[![PyPI][pypi-version]][pypi-apimatic-requests-client-adapter-url]
 [![Tests][test-badge]][test-url]
+[![Maintainability][maintainability-url]][code-climate-url]
+[![Test Coverage][test-coverage-url]][code-climate-url]
 [![Licence][license-badge]][license-url]
 
 ## Introduction
@@ -31,7 +33,11 @@ The requests client implementation also contains unit tests to ensure reliabilit
 * [Requests](https://pypi.org/project/requests/)
 
 [pypi-version]: https://img.shields.io/pypi/v/apimatic-requests-client-adapter
+[pypi-apimatic-requests-client-adapter-url]: https://pypi.org/project/apimatic-requests-client-adapter/
 [test-badge]: https://github.com/apimatic/requests-client-adapter/actions/workflows/test-runner.yml/badge.svg
 [test-url]: https://github.com/apimatic/requests-client-adapter/actions/workflows/test-runner.yml
+[code-climate-url]: https://codeclimate.com/github/apimatic/requests-client-adapter
+[maintainability-url]: https://api.codeclimate.com/v1/badges/1daeb05c58b9a252043c/maintainability
+[test-coverage-url]: https://api.codeclimate.com/v1/badges/1daeb05c58b9a252043c/test_coverage
 [license-badge]: https://img.shields.io/badge/licence-APIMATIC-blue
 [license-url]: LICENSE

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,2 +1,2 @@
 pytest~=7.1.3
-pytest-cov~=3.0.0
+coverage~=6.5.0


### PR DESCRIPTION
This PR bears the change for CI to automate the test coverage report uploading for the code-climate tool.

closes #8