### PR TITLE
docs(incorrect-homepage-url): fix url in package setup file

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -12,13 +12,13 @@ else:
 
 setup(
     name='apimatic-requests-client-adapter',
-    version='0.1.0',
+    version='0.1.1',
     description='An adapter for requests client library consumed by the SDKs generated with APIMatic',
     long_description=long_description,
     long_description_content_type="text/markdown",
     author='APIMatic',
     author_email='support@apimatic.io',
-    url='https://apimatic.io',
+    url='https://github.com/apimatic/requests-client-adapter',
     packages=find_packages(),
     install_requires=[
         'apimatic-core-interfaces~=0.1.0',


### PR DESCRIPTION
This PR bears the fix in the url property of the package setup configurations. The url is now pointing towards the project repository hosted on github.

closes #11