### PR TITLE
fix(retry-error): handle retry error when retries are configured

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ else:
 
 setup(
     name='apimatic-requests-client-adapter',
-    version='0.1.5',
+    version='0.1.6',
     description='An adapter for requests client library consumed by the SDKs generated with APIMatic',
     long_description=long_description,
     long_description_content_type="text/markdown",


### PR DESCRIPTION
## What
This PR fixes the unhandled retry error that hides the actual response from the server. Also, it fixes the case when it throws the exception when the retry count is set to 0 and this was a wrong behavior. This fix now returns the actual response after the last retry and does not throw any exception.

## Why
This was a bug from the start of the retry feature whenever the retry configuration was set. The issue was with the `RetryError` exception which hides the actual server response and we don't want the actual server response to be hidden from the users.

closes #31

## Type of change
Select multiple if applicable.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause a breaking change)
- [ ] Tests (adds or updates tests)
- [ ] Documentation (adds or updates documentation)
- [ ] Refactor (style improvements, performance improvements, code refactoring)
- [ ] Revert (reverts a commit)
- [ ] CI/Build (adds or updates a script, change in external dependencies)

## Dependency Change
If a new dependency is being added, please ensure that it adheres to the following guideline https://github.com/apimatic/apimatic-codegen/wiki/Policy-of-adding-new-dependencies-in-the-core-libraries

## Breaking change
If the PR is introducing a breaking change, please ensure that it adheres to the following guideline https://github.com/apimatic/apimatic-codegen/wiki/Guidelines-for-maintaining-core-libraries

## Testing
List the steps that were taken to test the changes

## Checklist
- [x] My code follows the coding conventions
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have added new unit tests
