### PR TITLE
docs: compatibility with python 3.12 and 3.13

### DIFF
--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -17,7 +17,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        python: ["3.7", "3.8", "3.9", "3.10", "3.11"]
+        python: ["3.7", "3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]
     steps:
       - uses: actions/checkout@v3
       - name: Setup Python
@@ -40,5 +40,5 @@ jobs:
         run: |
               for file in $(find -name '*.py')
               do
-               pylint --disable=R,C,W "$file" --fail-under=10;    
+               pylint --disable=R,C,W "$file" --fail-under=10;
               done

--- a/.github/workflows/test-runner.yml
+++ b/.github/workflows/test-runner.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        python: ["3.7", "3.8", "3.9", "3.10", "3.11"]
+        python: ["3.7", "3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]
     steps:
       - uses: actions/checkout@v3
       - name: Setup Python
@@ -33,7 +33,7 @@ jobs:
       - name: Generate coverage report
         run: coverage xml
       - name: Upload coverage report
-        if: ${{ matrix.os == 'ubuntu-latest' && matrix.python == '3.11' && github.actor != 'dependabot[bot]' }}
+        if: ${{ matrix.os == 'ubuntu-latest' && matrix.python == '3.13' && github.actor != 'dependabot[bot]' }}
         uses: paambaati/codeclimate-action@v3.0.0
         env:
           CC_TEST_REPORTER_ID: ${{ secrets.CODE_CLIMATE_TEST_REPORTER_ID }}

--- a/README.md
+++ b/README.md
@@ -5,12 +5,12 @@
 [![Licence][license-badge]][license-url]
 
 ## Introduction
-Requests is a simple, yet elegant, HTTP library. This repository contains the client implementation that uses the requests library for python SDK provided by APIMatic. 
+Requests is a simple, yet elegant, HTTP library. This repository contains the client implementation that uses the requests library for python SDK provided by APIMatic.
 
-## Version supported 
-Currenty APIMatic supports  `Python version 3.7 - 3.11`  hence the apimatic-requests-client-adapter will need the same versions to be supported.
+## Version supported
+Currenty APIMatic supports  `Python version 3.7+`  hence the apimatic-requests-client-adapter will need the same versions to be supported.
 
-## Installation 
+## Installation
 Simply run the command below in your SDK as the apimatic-requests-client-adapter will be added as a dependency in the SDK.
 ```python
 pip install apimatic-requests-client-adapter
@@ -19,9 +19,9 @@ pip install apimatic-requests-client-adapter
 
 | Method                                                                             | Description                                                                      |
 | -----------------------------------------------------------------------------------|----------------------------------------------------------------------------------|
-| [`create_default_http_client`](apimatic_requests_client_adapter/requests_client.py)| function to creat a defaultp http client                                         | 
-| [`force_retries`](apimatic_requests_client_adapter/requests_client.py)             | Reset retries according to each request                                          | 
-| [`execute`](apimatic_requests_client_adapter/requests_client.py)                   | Execute a given HttpRequest to get a string response back                        | 
+| [`create_default_http_client`](apimatic_requests_client_adapter/requests_client.py)| function to creat a defaultp http client                                         |
+| [`force_retries`](apimatic_requests_client_adapter/requests_client.py)             | Reset retries according to each request                                          |
+| [`execute`](apimatic_requests_client_adapter/requests_client.py)                   | Execute a given HttpRequest to get a string response back                        |
 | [`convert_response`](apimatic_requests_client_adapter/requests_client.py)          | Converts the Response object of the CoreHttpClient into a CoreHttpResponse object|
 
 ## Tests

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 apimatic-core-interfaces~=0.1.0
 requests~=2.31
 cachecontrol~=0.12.6
+setuptools>=68.0.0


### PR DESCRIPTION
## What
- Updated docs to reflect compatibility with python 3.12 and 3.13
- Added setuptools as an explicit dependency.

## Why
This PR was created to match [this PR](https://github.com/apimatic/core-lib-python/pull/85) in the core library.

Previously, setuptools was bundled with Python<=3.11 but has now [been removed](https://github.com/python/cpython/pull/101039) by default. So, we need to add it explicitly in requirements.txt. We should consider adding pyproject.toml to our python repos [as that is now the standard](https://packaging.python.org/en/latest/discussions/setup-py-deprecated/#is-pyproject-toml-mandatory).

## Type of change
Select multiple if applicable.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause a breaking change)
- [ ] Tests (adds or updates tests)
- [x] Documentation (adds or updates documentation)
- [ ] Refactor (style improvements, performance improvements, code refactoring)
- [ ] Revert (reverts a commit)
- [x] CI/Build (adds or updates a script, change in external dependencies)

## Testing
See [this PR](https://github.com/apimatic/apimatic-codegen/pull/4096).

## Checklist
- [ ] My code follows the coding conventions
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added new unit tests
