### PR TITLE
ci: migrate test coverage from CodeClimate to SonarCloud

### DIFF
--- a/.github/workflows/test-runner.yml
+++ b/.github/workflows/test-runner.yml
@@ -32,11 +32,9 @@ jobs:
         run: coverage run -m pytest
       - name: Generate coverage report
         run: coverage xml
-      - name: Upload coverage report
-        if: ${{ matrix.os == 'ubuntu-latest' && matrix.python == '3.13' && github.actor != 'dependabot[bot]' }}
-        uses: paambaati/codeclimate-action@v3.0.0
+      - name: SonarQube Scan
+        if: ${{ matrix.python == '3.13' && github.actor != 'dependabot[bot]' }}
+        uses: SonarSource/sonarqube-scan-action@v5.2.0
         env:
-          CC_TEST_REPORTER_ID: ${{ secrets.CODE_CLIMATE_TEST_REPORTER_ID }}
-        with:
-          coverageLocations: |
-            ${{github.workspace}}/coverage.xml:coverage.py
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -1,7 +1,9 @@
 # apimatic-requests-client-adapter
 [![PyPI][pypi-version]][pypi-apimatic-requests-client-adapter-url]
 [![Tests][test-badge]][test-url]
-[![Test Coverage][test-coverage-url]][code-climate-url]
+[![Test Coverage][coverage-badge]][coverage-url]
+[![Maintainability Rating][maintainability-badge]][maintainability-url]
+[![Vulnerabilities][vulnerabilities-badge]][vulnerabilities-url]
 [![Licence][license-badge]][license-url]
 
 ## Introduction
@@ -35,8 +37,11 @@ The requests client implementation also contains unit tests to ensure reliabilit
 [pypi-apimatic-requests-client-adapter-url]: https://pypi.org/project/apimatic-requests-client-adapter/
 [test-badge]: https://github.com/apimatic/requests-client-adapter/actions/workflows/test-runner.yml/badge.svg
 [test-url]: https://github.com/apimatic/requests-client-adapter/actions/workflows/test-runner.yml
-[code-climate-url]: https://codeclimate.com/github/apimatic/requests-client-adapter
-[maintainability-url]: https://api.codeclimate.com/v1/badges/1daeb05c58b9a252043c/maintainability
-[test-coverage-url]: https://api.codeclimate.com/v1/badges/1daeb05c58b9a252043c/test_coverage
+[coverage-badge]: https://sonarcloud.io/api/project_badges/measure?project=apimatic_requests-client-adapter&metric=coverage
+[coverage-url]: https://sonarcloud.io/summary/new_code?id=apimatic_requests-client-adapter
+[maintainability-badge]: https://sonarcloud.io/api/project_badges/measure?project=apimatic_requests-client-adapter&metric=sqale_rating
+[maintainability-url]: https://sonarcloud.io/summary/new_code?id=apimatic_requests-client-adapter
+[vulnerabilities-badge]: https://sonarcloud.io/api/project_badges/measure?project=apimatic_requests-client-adapter&metric=vulnerabilities
+[vulnerabilities-url]: https://sonarcloud.io/summary/new_code?id=apimatic_requests-client-adapter
 [license-badge]: https://img.shields.io/badge/licence-MIT-blue
 [license-url]: LICENSE

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,0 +1,10 @@
+sonar.projectKey=apimatic_requests-client-adapter
+sonar.projectName=Requests Client Adapter Python
+sonar.organization=apimatic
+sonar.host.url=https://sonarcloud.io
+sonar.sourceEncoding=UTF-8
+
+sonar.sources=apimatic_requests_client_adapter
+sonar.tests=tests
+
+sonar.python.coverage.reportPaths=coverage.xml


### PR DESCRIPTION
This PR migrates the coverage reporting from Code Climate to SonarCloud. It also adds badges from SonarCloud in Readme.